### PR TITLE
Fix README tree login module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To use with private credentials, set the following GitHub repository secrets:
 ```
 chatgpt-scraper/
 ├── scrape_chatgpt.py    # Main script with enhanced scraping logic
-├── login_module.py      # Optional authentication module
+├── login.py             # Optional authentication module
 ├── cleanup.py           # Utility to remove old scrapes
 ├── tests/               # Test suite
 │   └── test_scraper.py  # Unit tests


### PR DESCRIPTION
## Summary
- correct README project structure entry for the authentication file

## Testing
- `python -m pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_683f80981f18832cbd292cf55f289553