### PR TITLE
Fix README path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A robust Python script using Selenium to track changes on ChatGPT's interface by
 
 ```bash
 git clone <your-repo-url>
-cd chatgpt-scraper
+cd selenium-scraper
 ```
 
 2. Install required packages:


### PR DESCRIPTION
## Summary
- correct install docs to change into selenium-scraper directory

## Testing
- `python -m pytest tests/` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_683f808ac520832cb98e2f6e17831be9