### PR TITLE
Fix docstring for get_previous_file

### DIFF
--- a/scrape_chatgpt.py
+++ b/scrape_chatgpt.py
@@ -236,7 +236,7 @@ class ContentHandler:
             return None
     
     def get_previous_file(self) -> Optional[Path]:
-        """Get the most recent file from the previous day."""
+        """Return the most recently scraped file regardless of date."""
         try:
             output_dir = Path(self.config.repo_path) / 'scraped_pages'
             if not output_dir.exists():


### PR DESCRIPTION
## Summary
- clarify ContentHandler.get_previous_file docstring
- install dependencies to run tests

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f83c09f74832c99eacf916d910a34