### PR TITLE
Add remote debugging port to Chrome options

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ If CloudFlare challenges persist:
 2. Ensure your Chrome and ChromeDriver versions match
 3. Try running without headless mode for debugging
 
+### Chrome Startup Issues
+
+If you encounter a `DevToolsActivePort file doesn't exist` error, make sure
+Chrome is launched with the `--remote-debugging-port=9222` flag. The script adds
+this option automatically, but outdated Chrome/ChromeDriver versions can still
+trigger the issue.
+
 ### Authentication Issues
 
 If you're having login problems:

--- a/scrape_chatgpt.py
+++ b/scrape_chatgpt.py
@@ -42,6 +42,7 @@ class SeleniumScraper:
         chrome_options.add_argument('--headless=new')
         chrome_options.add_argument('--no-sandbox')
         chrome_options.add_argument('--disable-dev-shm-usage')
+        chrome_options.add_argument('--remote-debugging-port=9222')
         chrome_options.add_argument('--disable-blink-features=AutomationControlled')
         chrome_options.add_argument('--disable-extensions')
         chrome_options.add_argument('--disable-gpu')
@@ -88,6 +89,7 @@ class SeleniumScraper:
             chrome_options.add_argument('--headless=new')
             chrome_options.add_argument('--no-sandbox')
             chrome_options.add_argument('--disable-dev-shm-usage')
+            chrome_options.add_argument('--remote-debugging-port=9222')
             if self.config.chrome_binary_path:
                 chrome_options.binary_location = self.config.chrome_binary_path
             


### PR DESCRIPTION
## Summary
- fix headless Chrome startup by adding `--remote-debugging-port=9222`
- document DevToolsActivePort troubleshooting tips

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414d0c8cf4832c942704fe9b8982cf