### PR TITLE
Load .env before reading config variables

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,6 +6,9 @@ from dotenv import load_dotenv
 from fake_useragent import UserAgent
 from distutils.util import strtobool
 
+# Load environment variables from a .env file before accessing them
+load_dotenv()
+
 # ----------------------- runtime switches ----------------------------------
 HEADLESS = bool(strtobool(os.getenv("HEADLESS", "1")))  # accepts 0/1 yes/no true/false
 
@@ -40,7 +43,6 @@ class Config:
     
     @classmethod
     def from_env(cls) -> 'Config':
-        load_dotenv()
         return cls(
             chrome_driver_path=os.getenv('CHROME_DRIVER_PATH'),
             website_url=os.getenv('WEBSITE_URL', 'https://chat.openai.com'),


### PR DESCRIPTION
## Summary
- load environment variables from `.env` before accessing configuration
- define `HEADLESS` after dotenv load and remove redundant load

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68941c25e7e8832cb31e58150991461d